### PR TITLE
Overloaded +, -, *, /, +=, -=, *=, /=, <, >, <=, >=, == for BigUint and native unsigned integers

### DIFF
--- a/Sources/Space/types/BigUint.swift
+++ b/Sources/Space/types/BigUint.swift
@@ -82,6 +82,66 @@ extension BigUint: Equatable {
 }
 
 extension BigUint {
+    public static func == (left: BigUint, right: UInt8) -> Bool {
+        left == BigUint(value: right)
+    }
+    
+    public static func == (left: UInt8, right: BigUint) -> Bool {
+        BigUint(value: left) == right
+    }
+    
+    public static func == (left: BigUint, right: UInt16) -> Bool {
+        left == BigUint(value: right)
+    }
+    
+    public static func == (left: UInt16, right: BigUint) -> Bool {
+        BigUint(value: left) == right
+    }
+    
+    public static func == (left: BigUint, right: UInt32) -> Bool {
+        left == BigUint(value: right)
+    }
+    
+    public static func == (left: UInt32, right: BigUint) -> Bool {
+        BigUint(value: left) == right
+    }
+    
+    public static func == (left: BigUint, right: UInt64) -> Bool {
+        left == BigUint(value: right)
+    }
+    
+    public static func == (left: UInt64, right: BigUint) -> Bool {
+        BigUint(value: left) == right
+    }
+    
+    public static func == (left: BigUint, right: IntegerLiteralType) -> Bool {
+        left == BigUint(value: Int64(right))
+    }
+    
+    public static func == (left: IntegerLiteralType, right: BigUint) -> Bool {
+        BigUint(value: Int64(left)) == right
+    }
+    
+    public static func != (left: BigUint, right: UInt8) -> Bool {
+        return left != BigUint(value: right)
+    }
+
+    public static func != (left: BigUint, right: UInt16) -> Bool {
+        return left != BigUint(value: right)
+    }
+
+    public static func != (left: BigUint, right: UInt32) -> Bool {
+        return left != BigUint(value: right)
+    }
+
+    public static func != (left: BigUint, right: UInt64) -> Bool {
+        return left != BigUint(value: right)
+    }
+
+    public static func != (left: BigUint, right: IntegerLiteralType) -> Bool {
+        return left != BigUint(value: Int64(right))
+    }
+    
     public static func + (left: BigUint, right: BigUint) -> BigUint {
         let handle = getNextHandle()
         API.bigIntAdd(destHandle: handle, lhsHandle: left.handle, rhsHandle: right.handle)
@@ -133,6 +193,26 @@ extension BigUint {
         left = left + right
     }
     
+    public static func += (left: inout BigUint, right: UInt8) {
+        left = left + BigUint(value: right)
+    }
+
+    public static func += (left: inout BigUint, right: UInt16) {
+        left = left + BigUint(value: right)
+    }
+
+    public static func += (left: inout BigUint, right: UInt32) {
+        left = left + BigUint(value: right)
+    }
+
+    public static func += (left: inout BigUint, right: UInt64) {
+        left = left + BigUint(value: right)
+    }
+
+    public static func += (left: inout BigUint, right: IntegerLiteralType) {
+        left = left + BigUint(value: Int64(right))
+    }
+    
     public static func - (lhs: BigUint, rhs: BigUint) -> BigUint {
         guard lhs >= rhs else {
             smartContractError(message: Buffer(stringLiteral: BIG_UINT_SUB_NEGATIVE))
@@ -144,11 +224,139 @@ extension BigUint {
         return BigUint(handle: handle)
     }
     
+    public static func - (left: BigUint, right: UInt8) -> BigUint {
+        left - BigUint(value: right)
+    }
+    
+    public static func - (left: UInt8, right: BigUint) -> BigUint {
+        BigUint(value: left) - right
+    }
+    
+    public static func - (left: BigUint, right: UInt16) -> BigUint {
+        left - BigUint(value: right)
+    }
+    
+    public static func - (left: UInt16, right: BigUint) -> BigUint {
+        BigUint(value: left) - right
+    }
+    
+    public static func - (left: BigUint, right: UInt32) -> BigUint {
+        left - BigUint(value: right)
+    }
+    
+    public static func - (left: UInt32, right: BigUint) -> BigUint {
+        BigUint(value: left) - right
+    }
+    
+    public static func - (left: BigUint, right: UInt64) -> BigUint {
+        left - BigUint(value: right)
+    }
+    
+    public static func - (left: UInt64, right: BigUint) -> BigUint {
+        BigUint(value: left) - right
+    }
+    
+    public static func - (left: BigUint, right: IntegerLiteralType) -> BigUint {
+        left - BigUint(value: Int64(right))
+    }
+    
+    public static func - (left: IntegerLiteralType, right: BigUint) -> BigUint {
+        BigUint(value: Int64(left)) - right
+    }
+    
+    public static func -= (left: inout BigUint, right: BigUint) {
+        left = left - right
+    }
+    
+    public static func -= (left: inout BigUint, right: UInt8) {
+        left = left - BigUint(value: right)
+    }
+
+    public static func -= (left: inout BigUint, right: UInt16) {
+        left = left - BigUint(value: right)
+    }
+
+    public static func -= (left: inout BigUint, right: UInt32) {
+        left = left - BigUint(value: right)
+    }
+
+    public static func -= (left: inout BigUint, right: UInt64) {
+        left = left - BigUint(value: right)
+    }
+
+    public static func -= (left: inout BigUint, right: IntegerLiteralType) {
+        left = left - BigUint(value: Int64(right))
+    }
+    
     public static func * (lhs: BigUint, rhs: BigUint) -> BigUint {
         let handle = getNextHandle()
         API.bigIntMul(destHandle: handle, lhsHandle: lhs.handle, rhsHandle: rhs.handle)
         
         return BigUint(handle: handle)
+    }
+    
+    public static func * (left: BigUint, right: UInt8) -> BigUint {
+        left * BigUint(value: right)
+    }
+    
+    public static func * (left: UInt8, right: BigUint) -> BigUint {
+        BigUint(value: left) * right
+    }
+    
+    public static func * (left: BigUint, right: UInt16) -> BigUint {
+        left * BigUint(value: right)
+    }
+    
+    public static func * (left: UInt16, right: BigUint) -> BigUint {
+        BigUint(value: left) * right
+    }
+    
+    public static func * (left: BigUint, right: UInt32) -> BigUint {
+        left * BigUint(value: right)
+    }
+    
+    public static func * (left: UInt32, right: BigUint) -> BigUint {
+        BigUint(value: left) * right
+    }
+    
+    public static func * (left: BigUint, right: UInt64) -> BigUint {
+        left * BigUint(value: right)
+    }
+    
+    public static func * (left: UInt64, right: BigUint) -> BigUint {
+        BigUint(value: left) * right
+    }
+    
+    public static func * (left: BigUint, right: IntegerLiteralType) -> BigUint {
+        left * BigUint(value: Int64(right))
+    }
+    
+    public static func * (left: IntegerLiteralType, right: BigUint) -> BigUint {
+        BigUint(value: Int64(left)) * right
+    }
+    
+    public static func *= (left: inout BigUint, right: BigUint) {
+        left = left * right
+    }
+    
+    public static func *= (left: inout BigUint, right: UInt8) {
+        left = left * BigUint(value: right)
+    }
+
+    public static func *= (left: inout BigUint, right: UInt16) {
+        left = left * BigUint(value: right)
+    }
+
+    public static func *= (left: inout BigUint, right: UInt32) {
+        left = left * BigUint(value: right)
+    }
+
+    public static func *= (left: inout BigUint, right: UInt64) {
+        left = left * BigUint(value: right)
+    }
+
+    public static func *= (left: inout BigUint, right: IntegerLiteralType) {
+        left = left * BigUint(value: Int64(right))
     }
     
     public static func / (lhs: BigUint, rhs: BigUint) -> BigUint {
@@ -159,6 +367,70 @@ extension BigUint {
         return BigUint(handle: handle)
     }
     
+    public static func / (left: BigUint, right: UInt8) -> BigUint {
+        left / BigUint(value: right)
+    }
+    
+    public static func / (left: UInt8, right: BigUint) -> BigUint {
+        BigUint(value: left) / right
+    }
+    
+    public static func / (left: BigUint, right: UInt16) -> BigUint {
+        left / BigUint(value: right)
+    }
+    
+    public static func / (left: UInt16, right: BigUint) -> BigUint {
+        BigUint(value: left) / right
+    }
+    
+    public static func / (left: BigUint, right: UInt32) -> BigUint {
+        left / BigUint(value: right)
+    }
+    
+    public static func / (left: UInt32, right: BigUint) -> BigUint {
+        BigUint(value: left) / right
+    }
+    
+    public static func / (left: BigUint, right: UInt64) -> BigUint {
+        left / BigUint(value: right)
+    }
+    
+    public static func / (left: UInt64, right: BigUint) -> BigUint {
+        BigUint(value: left) / right
+    }
+    
+    public static func / (left: BigUint, right: IntegerLiteralType) -> BigUint {
+        left / BigUint(value: Int64(right))
+    }
+    
+    public static func / (left: IntegerLiteralType, right: BigUint) -> BigUint {
+        BigUint(value: Int64(left)) / right
+    }
+    
+    public static func /= (left: inout BigUint, right: BigUint) {
+        left = left / right
+    }
+    
+    public static func /= (left: inout BigUint, right: UInt8) {
+        left = left / BigUint(value: right)
+    }
+
+    public static func /= (left: inout BigUint, right: UInt16) {
+        left = left / BigUint(value: right)
+    }
+
+    public static func /= (left: inout BigUint, right: UInt32) {
+        left = left / BigUint(value: right)
+    }
+
+    public static func /= (left: inout BigUint, right: UInt64) {
+        left = left / BigUint(value: right)
+    }
+
+    public static func /= (left: inout BigUint, right: IntegerLiteralType) {
+        left = left / BigUint(value: Int64(right))
+    }
+    
     public static func % (lhs: BigUint, rhs: BigUint) -> BigUint {
         // TODO: be sure rhs == 0 throws an error on the SpaceVM (critical)
         let handle = getNextHandle()
@@ -167,22 +439,248 @@ extension BigUint {
         return BigUint(handle: handle)
     }
     
+    public static func % (left: BigUint, right: UInt8) -> BigUint {
+        left % BigUint(value: right)
+    }
+    
+    public static func % (left: UInt8, right: BigUint) -> BigUint {
+        BigUint(value: left) % right
+    }
+    
+    public static func % (left: BigUint, right: UInt16) -> BigUint {
+        left % BigUint(value: right)
+    }
+    
+    public static func % (left: UInt16, right: BigUint) -> BigUint {
+        BigUint(value: left) % right
+    }
+    
+    public static func % (left: BigUint, right: UInt32) -> BigUint {
+        left % BigUint(value: right)
+    }
+    
+    public static func % (left: UInt32, right: BigUint) -> BigUint {
+        BigUint(value: left) % right
+    }
+    
+    public static func % (left: BigUint, right: UInt64) -> BigUint {
+        left % BigUint(value: right)
+    }
+    
+    public static func % (left: UInt64, right: BigUint) -> BigUint {
+        BigUint(value: left) % right
+    }
+    
+    public static func % (left: BigUint, right: IntegerLiteralType) -> BigUint {
+        left % BigUint(value: Int64(right))
+    }
+    
+    public static func % (left: IntegerLiteralType, right: BigUint) -> BigUint {
+        BigUint(value: Int64(left)) % right
+    }
+    
+    public static func %= (left: inout BigUint, right: BigUint) {
+        left = left % right
+    }
+    
+    public static func %= (left: inout BigUint, right: UInt8) {
+        left = left % BigUint(value: right)
+    }
+
+    public static func %= (left: inout BigUint, right: UInt16) {
+        left = left % BigUint(value: right)
+    }
+
+    public static func %= (left: inout BigUint, right: UInt32) {
+        left = left % BigUint(value: right)
+    }
+
+    public static func %= (left: inout BigUint, right: UInt64) {
+        left = left % BigUint(value: right)
+    }
+
+    public static func %= (left: inout BigUint, right: IntegerLiteralType) {
+        left = left % BigUint(value: Int64(right))
+    }
+
+    
     public static func > (lhs: BigUint, rhs: BigUint) -> Bool {
         let compareResult = API.bigIntCompare(lhsHandle: lhs.handle, rhsHandle: rhs.handle)
         
         return compareResult == 1
     }
     
+    public static func > (lhs: BigUint, rhs: UInt8) -> Bool {
+        lhs > BigUint(value: rhs)
+    }
+    
+    public static func > (lhs: UInt8, rhs: BigUint) -> Bool {
+        BigUint(value: lhs) > rhs
+    }
+    
+    public static func > (lhs: BigUint, rhs: UInt16) -> Bool {
+        lhs > BigUint(value: rhs)
+    }
+    
+    public static func > (lhs: UInt16, rhs: BigUint) -> Bool {
+        BigUint(value: lhs) > rhs
+    }
+    
+    public static func > (lhs: BigUint, rhs: UInt32) -> Bool {
+        lhs > BigUint(value: rhs)
+    }
+    
+    public static func > (lhs: UInt32, rhs: BigUint) -> Bool {
+        BigUint(value: lhs) > rhs
+    }
+    
+    public static func > (lhs: BigUint, rhs: UInt64) -> Bool {
+        lhs > BigUint(value: rhs)
+    }
+    
+    public static func > (lhs: UInt64, rhs: BigUint) -> Bool {
+        BigUint(value: lhs) > rhs
+    }
+    
+    public static func > (lhs: BigUint, rhs: IntegerLiteralType) -> Bool {
+        lhs > BigUint(value: Int64(rhs))
+    }
+    
+    public static func > (lhs: IntegerLiteralType, rhs: BigUint) -> Bool {
+        BigUint(value: Int64(lhs)) > rhs
+    }
+    
     public static func <= (lhs: BigUint, rhs: BigUint) -> Bool {
         !(lhs > rhs)
     }
+    
+    public static func <= (lhs: BigUint, rhs: UInt8) -> Bool {
+        lhs <= BigUint(value: rhs)
+    }
+
+    public static func <= (lhs: UInt8, rhs: BigUint) -> Bool {
+        BigUint(value: lhs) <= rhs
+    }
+
+    public static func <= (lhs: BigUint, rhs: UInt16) -> Bool {
+        lhs <= BigUint(value: rhs)
+    }
+
+    public static func <= (lhs: UInt16, rhs: BigUint) -> Bool {
+        BigUint(value: lhs) <= rhs
+    }
+
+    public static func <= (lhs: BigUint, rhs: UInt32) -> Bool {
+        lhs <= BigUint(value: rhs)
+    }
+
+    public static func <= (lhs: UInt32, rhs: BigUint) -> Bool {
+        BigUint(value: lhs) <= rhs
+    }
+
+    public static func <= (lhs: BigUint, rhs: UInt64) -> Bool {
+        lhs <= BigUint(value: rhs)
+    }
+
+    public static func <= (lhs: UInt64, rhs: BigUint) -> Bool {
+        BigUint(value: lhs) <= rhs
+    }
+
+    public static func <= (lhs: BigUint, rhs: IntegerLiteralType) -> Bool {
+        lhs <= BigUint(value: Int64(rhs))
+    }
+
+    public static func <= (lhs: IntegerLiteralType, rhs: BigUint) -> Bool {
+        BigUint(value: Int64(lhs)) <= rhs
+    }
+
     
     public static func < (lhs: BigUint, rhs: BigUint) -> Bool {
         lhs <= rhs && lhs != rhs
     }
     
+    public static func < (lhs: BigUint, rhs: UInt8) -> Bool {
+        lhs < BigUint(value: rhs)
+    }
+
+    public static func < (lhs: UInt8, rhs: BigUint) -> Bool {
+        BigUint(value: lhs) < rhs
+    }
+
+    public static func < (lhs: BigUint, rhs: UInt16) -> Bool {
+        lhs < BigUint(value: rhs)
+    }
+
+    public static func < (lhs: UInt16, rhs: BigUint) -> Bool {
+        BigUint(value: lhs) < rhs
+    }
+
+    public static func < (lhs: BigUint, rhs: UInt32) -> Bool {
+        lhs < BigUint(value: rhs)
+    }
+
+    public static func < (lhs: UInt32, rhs: BigUint) -> Bool {
+        BigUint(value: lhs) < rhs
+    }
+
+    public static func < (lhs: BigUint, rhs: UInt64) -> Bool {
+        lhs < BigUint(value: rhs)
+    }
+
+    public static func < (lhs: UInt64, rhs: BigUint) -> Bool {
+        BigUint(value: lhs) < rhs
+    }
+
+    public static func < (lhs: BigUint, rhs: IntegerLiteralType) -> Bool {
+        lhs < BigUint(value: Int64(rhs))
+    }
+
+    public static func < (lhs: IntegerLiteralType, rhs: BigUint) -> Bool {
+        BigUint(value: Int64(lhs)) < rhs
+    }
+    
     public static func >= (lhs: BigUint, rhs: BigUint) -> Bool {
         lhs > rhs || lhs == rhs
+    }
+    
+    public static func >= (lhs: BigUint, rhs: UInt8) -> Bool {
+        lhs >= BigUint(value: rhs)
+    }
+
+    public static func >= (lhs: UInt8, rhs: BigUint) -> Bool {
+        BigUint(value: lhs) >= rhs
+    }
+
+    public static func >= (lhs: BigUint, rhs: UInt16) -> Bool {
+        lhs >= BigUint(value: rhs)
+    }
+
+    public static func >= (lhs: UInt16, rhs: BigUint) -> Bool {
+        BigUint(value: lhs) >= rhs
+    }
+
+    public static func >= (lhs: BigUint, rhs: UInt32) -> Bool {
+        lhs >= BigUint(value: rhs)
+    }
+
+    public static func >= (lhs: UInt32, rhs: BigUint) -> Bool {
+        BigUint(value: lhs) >= rhs
+    }
+
+    public static func >= (lhs: BigUint, rhs: UInt64) -> Bool {
+        lhs >= BigUint(value: rhs)
+    }
+
+    public static func >= (lhs: UInt64, rhs: BigUint) -> Bool {
+        BigUint(value: lhs) >= rhs
+    }
+
+    public static func >= (lhs: BigUint, rhs: IntegerLiteralType) -> Bool {
+        lhs >= BigUint(value: Int64(rhs))
+    }
+
+    public static func >= (lhs: IntegerLiteralType, rhs: BigUint) -> Bool {
+        BigUint(value: Int64(lhs)) >= rhs
     }
 }
 

--- a/Sources/Space/types/BigUint.swift
+++ b/Sources/Space/types/BigUint.swift
@@ -21,7 +21,7 @@ public struct BigUint {
     
     public init(value: Int32) {
         if value < 0 {
-            smartContractError(message: "Cannot convert negative Int64 to BigUint.")
+            smartContractError(message: "Cannot convert negative Int32 to BigUint.")
         }
         
         self.init(value: value.toBytes8())
@@ -83,6 +83,38 @@ extension BigUint {
         API.bigIntAdd(destHandle: handle, lhsHandle: left.handle, rhsHandle: right.handle)
         
         return BigUint(handle: handle)
+    }
+    
+    public static func + (left: BigUint, right: UInt8) -> BigUint {
+        left + BigUint(value: right)
+    }
+    
+    public static func + (left: UInt8, right: BigUint) -> BigUint {
+        BigUint(value: left) + right
+    }
+    
+    public static func + (left: BigUint, right: UInt32) -> BigUint {
+        left + BigUint(value: right)
+    }
+    
+    public static func + (left: UInt32, right: BigUint) -> BigUint {
+        BigUint(value: left) + right
+    }
+    
+    public static func + (left: BigUint, right: UInt64) -> BigUint {
+        left + BigUint(value: right)
+    }
+    
+    public static func + (left: UInt64, right: BigUint) -> BigUint {
+        BigUint(value: left) + right
+    }
+    
+    public static func + (left: BigUint, right: IntegerLiteralType) -> BigUint {
+        left + BigUint(value: Int64(right))
+    }
+    
+    public static func + (left: IntegerLiteralType, right: BigUint) -> BigUint {
+        BigUint(value: Int64(left)) + right
     }
     
     public static func += (left: inout BigUint, right: BigUint) {

--- a/Sources/Space/types/BigUint.swift
+++ b/Sources/Space/types/BigUint.swift
@@ -97,6 +97,14 @@ extension BigUint {
         BigUint(value: left) + right
     }
     
+    public static func + (left: BigUint, right: UInt16) -> BigUint {
+        left + BigUint(value: right)
+    }
+    
+    public static func + (left: UInt16, right: BigUint) -> BigUint {
+        BigUint(value: left) + right
+    }
+    
     public static func + (left: BigUint, right: UInt32) -> BigUint {
         left + BigUint(value: right)
     }

--- a/Tests/BigUintTests/BigUintTests.swift
+++ b/Tests/BigUintTests/BigUintTests.swift
@@ -101,6 +101,24 @@ final class BigUintTests: ContractTestCase {
         XCTAssertEqual(result, 3)
     }
     
+    func testAddBigUintAndUInt16() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt16 = 2
+        
+        let result = bigUint + integer
+        
+        XCTAssertEqual(result, 3)
+    }
+    
+    func testAddUInt16AndBigUint() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt16 = 2
+        
+        let result = integer + bigUint
+        
+        XCTAssertEqual(result, 3)
+    }
+    
     func testAddBigUintAndUInt32() throws {
         let bigUint: BigUint = 1
         let integer: UInt32 = 2

--- a/Tests/BigUintTests/BigUintTests.swift
+++ b/Tests/BigUintTests/BigUintTests.swift
@@ -19,6 +19,20 @@ import Space
         let bigUint2: BigUint = 0
         let _ = bigUint1 / bigUint2
     }
+    
+    public func testAddBigUintAndNegativeLiteralShouldFail() {
+        let bigUint: BigUint = 1
+        let integer = -1
+        
+        let _ = bigUint + integer
+    }
+    
+    public func testAddNegativeLiteralAndBigUintShouldFail() {
+        let bigUint: BigUint = 1
+        let integer = -1
+        
+        let _ = integer + bigUint
+    }
 }
 
 final class BigUintTests: ContractTestCase {
@@ -67,6 +81,98 @@ final class BigUintTests: ContractTestCase {
         let result = bigUint1 + bigUint2
         
         XCTAssertEqual(result, 3)
+    }
+    
+    func testAddBigUintAndUInt8() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt8 = 2
+        
+        let result = bigUint + integer
+        
+        XCTAssertEqual(result, 3)
+    }
+    
+    func testAddUInt8AndBigUint() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt8 = 2
+        
+        let result = integer + bigUint
+        
+        XCTAssertEqual(result, 3)
+    }
+    
+    func testAddBigUintAndUInt32() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt32 = 2
+        
+        let result = bigUint + integer
+        
+        XCTAssertEqual(result, 3)
+    }
+    
+    func testAddUInt32AndBigUint() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt32 = 2
+        
+        let result = integer + bigUint
+        
+        XCTAssertEqual(result, 3)
+    }
+    
+    func testAddUInt64AndBigUint() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt64 = 2
+        
+        let result = integer + bigUint
+        
+        XCTAssertEqual(result, 3)
+    }
+    
+    func testAddBigUintAndUInt64() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt64 = 2
+        
+        let result = bigUint + integer
+        
+        XCTAssertEqual(result, 3)
+    }
+    
+    func testAddBigUintAndLiteralInt() throws {
+        let bigUint: BigUint = 1
+        let integer = 2
+        
+        let result = bigUint + integer
+        
+        XCTAssertEqual(result, 3)
+    }
+    
+    func testAddLiteralIntAndBigUint() throws {
+        let bigUint: BigUint = 1
+        let integer = 2
+        
+        let result = integer + bigUint
+        
+        XCTAssertEqual(result, 3)
+    }
+    
+    func testAddBigUintAndNegativeLiteralInt() throws {
+        do {
+            try BigUintTestsContract.testable("contract").testAddBigUintAndNegativeLiteralShouldFail()
+            
+            XCTFail()
+        } catch {
+            XCTAssertEqual(error, .userError(message: "Cannot convert negative Int64 to BigUint."))
+        }
+    }
+    
+    func testAddNegativeLiteralIntAndBigUint() throws {
+        do {
+            try BigUintTestsContract.testable("contract").testAddNegativeLiteralAndBigUintShouldFail()
+            
+            XCTFail()
+        } catch {
+            XCTAssertEqual(error, .userError(message: "Cannot convert negative Int64 to BigUint."))
+        }
     }
     
     func testAddAssignBigUint() throws {

--- a/Tests/BigUintTests/BigUintTests.swift
+++ b/Tests/BigUintTests/BigUintTests.swift
@@ -33,6 +33,20 @@ import Space
         
         let _ = integer + bigUint
     }
+    
+    public func testRemoveBigUintAndNegativeLiteralShouldFail() {
+        let bigUint: BigUint = 1
+        let integer = -1
+        
+        let _ = bigUint - integer
+    }
+    
+    public func testRemoveNegativeLiteralAndBigUintShouldFail() {
+        let bigUint: BigUint = 1
+        let integer = -1
+        
+        let _ = integer - bigUint
+    }
 }
 
 final class BigUintTests: ContractTestCase {
@@ -72,6 +86,121 @@ final class BigUintTests: ContractTestCase {
         let bigUint2: BigUint = 2
         
         XCTAssertNotEqual(bigUint1, bigUint2)
+    }
+    
+    func testCompareBigUintAndUInt8() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt8 = 1
+        
+        XCTAssert(bigUint == integer)
+    }
+    
+    func testCompareUInt8AndBigUint() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt8 = 1
+        
+        XCTAssert(integer == bigUint)
+    }
+    
+    func testCompareBigUintAndUInt16() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt16 = 1
+        
+        XCTAssert(bigUint == integer)
+    }
+    
+    func testCompareUInt16AndBigUint() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt16 = 1
+        
+        XCTAssert(integer == bigUint)
+    }
+    
+    func testCompareBigUintAndUInt32() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt32 = 1
+        
+        XCTAssert(bigUint == integer)
+    }
+    
+    func testCompareUInt32AndBigUint() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt32 = 1
+        
+        XCTAssert(integer == bigUint)
+    }
+    
+    func testCompareBigUintAndUInt64() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt64 = 1
+        
+        XCTAssert(bigUint == integer)
+    }
+    
+    func testCompareUInt64AndBigUint() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt64 = 1
+        
+        XCTAssert(integer == bigUint)
+    }
+    
+    func testCompareBigUintAndLiteralInteger() throws {
+        let bigUint: BigUint = 1
+        let integer = 1
+        
+        XCTAssert(bigUint == integer)
+    }
+    
+    func testCompareLiteralIntegerAndBigUint() throws {
+        let bigUint: BigUint = 1
+        let integer = 1
+        
+        XCTAssert(integer == bigUint)
+    }
+    
+    func testNotEqualBigUintAndUInt8() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt8 = 5
+        let differentInteger: UInt8 = 3
+
+        XCTAssertFalse(bigUint != integer)
+        XCTAssert(bigUint != differentInteger)
+    }
+
+    func testNotEqualBigUintAndUInt16() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt16 = 5
+        let differentInteger: UInt16 = 3
+
+        XCTAssertFalse(bigUint != integer)
+        XCTAssert(bigUint != differentInteger)
+    }
+
+    func testNotEqualBigUintAndUInt32() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt32 = 5
+        let differentInteger: UInt32 = 3
+
+        XCTAssertFalse(bigUint != integer)
+        XCTAssert(bigUint != differentInteger)
+    }
+
+    func testNotEqualBigUintAndUInt64() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt64 = 5
+        let differentInteger: UInt64 = 3
+
+        XCTAssertFalse(bigUint != integer)
+        XCTAssert(bigUint != differentInteger)
+    }
+
+    func testNotEqualBigUintAndLiteralInteger() throws {
+        let bigUint: BigUint = 5
+        let integer = 5
+        let differentInteger = 3
+
+        XCTAssertFalse(bigUint != integer)
+        XCTAssert(bigUint != differentInteger)
     }
     
     func testAddTwoBigUint() throws {
@@ -173,9 +302,99 @@ final class BigUintTests: ContractTestCase {
         XCTAssertEqual(result, 3)
     }
     
-    func testAddBigUintAndNegativeLiteralInt() throws {
+    func testRemoveBigUintAndUInt8() throws {
+        let bigUint: BigUint = 2
+        let integer: UInt8 = 1
+        
+        let result = bigUint - integer
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testRemoveUInt8AndBigUint() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt8 = 2
+        
+        let result = integer - bigUint
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testRemoveBigUintAndUInt16() throws {
+        let bigUint: BigUint = 2
+        let integer: UInt16 = 1
+        
+        let result = bigUint - integer
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testRemoveUInt16AndBigUint() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt16 = 2
+        
+        let result = integer - bigUint
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testRemoveBigUintAndUInt32() throws {
+        let bigUint: BigUint = 2
+        let integer: UInt32 = 1
+        
+        let result = bigUint - integer
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testRemoveUInt32AndBigUint() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt32 = 2
+        
+        let result = integer - bigUint
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testRemoveUInt64AndBigUint() throws {
+        let bigUint: BigUint = 1
+        let integer: UInt64 = 2
+        
+        let result = integer - bigUint
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testRemoveBigUintAndUInt64() throws {
+        let bigUint: BigUint = 2
+        let integer: UInt64 = 1
+        
+        let result = bigUint - integer
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testRemoveBigUintAndLiteralInt() throws {
+        let bigUint: BigUint = 2
+        let integer = 1
+        
+        let result = bigUint - integer
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testRemoveLiteralIntAndBigUint() throws {
+        let bigUint: BigUint = 1
+        let integer = 2
+        
+        let result = integer - bigUint
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testRemoveBigUintAndNegativeLiteralInt() throws {
         do {
-            try BigUintTestsContract.testable("contract").testAddBigUintAndNegativeLiteralShouldFail()
+            try BigUintTestsContract.testable("contract").testRemoveBigUintAndNegativeLiteralShouldFail()
             
             XCTFail()
         } catch {
@@ -183,9 +402,9 @@ final class BigUintTests: ContractTestCase {
         }
     }
     
-    func testAddNegativeLiteralIntAndBigUint() throws {
+    func testRemoveNegativeLiteralIntAndBigUint() throws {
         do {
-            try BigUintTestsContract.testable("contract").testAddNegativeLiteralAndBigUintShouldFail()
+            try BigUintTestsContract.testable("contract").testRemoveNegativeLiteralAndBigUintShouldFail()
             
             XCTFail()
         } catch {
@@ -209,6 +428,52 @@ final class BigUintTests: ContractTestCase {
         
         XCTAssertEqual(result, 3)
     }
+    
+    func testAddAssignBigUintAndUInt8() throws {
+        var result: BigUint = 1
+        let addend: UInt8 = 2
+
+        result += addend
+
+        XCTAssertEqual(result, 3)
+    }
+
+    func testAddAssignBigUintAndUInt16() throws {
+        var result: BigUint = 1
+        let addend: UInt16 = 2
+
+        result += addend
+
+        XCTAssertEqual(result, 3)
+    }
+
+    func testAddAssignBigUintAndUInt32() throws {
+        var result: BigUint = 1
+        let addend: UInt32 = 2
+
+        result += addend
+
+        XCTAssertEqual(result, 3)
+    }
+
+    func testAddAssignBigUintAndUInt64() throws {
+        var result: BigUint = 1
+        let addend: UInt64 = 2
+
+        result += addend
+
+        XCTAssertEqual(result, 3)
+    }
+
+    func testAddAssignBigUintAndLiteralInteger() throws {
+        var result: BigUint = 1
+        let addend = 2
+
+        result += addend
+
+        XCTAssertEqual(result, 3)
+    }
+
     
     func testAddBigUintAndLiteral() throws {
         let bigUint1: BigUint = 1
@@ -237,6 +502,68 @@ final class BigUintTests: ContractTestCase {
         }
     }
     
+    func testSubstractAssignBigUint() throws {
+        var result: BigUint = 5
+        let bigUint: BigUint = 2
+        
+        result -= bigUint
+        
+        XCTAssertEqual(result, 3)
+    }
+    
+    func testSubstractAssignBigUintLiteral() throws {
+        var result: BigUint = 5
+        
+        result -= 2
+        
+        XCTAssertEqual(result, 3)
+    }
+    
+    func testSubtractAssignBigUintAndUInt8() throws {
+        var result: BigUint = 5
+        let subtrahend: UInt8 = 2
+
+        result -= subtrahend
+
+        XCTAssertEqual(result, 3)
+    }
+
+    func testSubtractAssignBigUintAndUInt16() throws {
+        var result: BigUint = 5
+        let subtrahend: UInt16 = 2
+
+        result -= subtrahend
+
+        XCTAssertEqual(result, 3)
+    }
+
+    func testSubtractAssignBigUintAndUInt32() throws {
+        var result: BigUint = 5
+        let subtrahend: UInt32 = 2
+
+        result -= subtrahend
+
+        XCTAssertEqual(result, 3)
+    }
+
+    func testSubtractAssignBigUintAndUInt64() throws {
+        var result: BigUint = 5
+        let subtrahend: UInt64 = 2
+
+        result -= subtrahend
+
+        XCTAssertEqual(result, 3)
+    }
+
+    func testSubtractAssignBigUintAndLiteralInteger() throws {
+        var result: BigUint = 5
+        let subtrahend = 2
+
+        result -= subtrahend
+
+        XCTAssertEqual(result, 3)
+    }
+    
     func testMultiplyTwoBigUint() throws {
         let bigUint1: BigUint = 2
         let bigUint2: BigUint = 3
@@ -245,6 +572,159 @@ final class BigUintTests: ContractTestCase {
         
         XCTAssertEqual(result, 6)
     }
+    
+    func testMultiplyBigUintAndUInt8() throws {
+        let bigUint: BigUint = 2
+        let integer: UInt8 = 3
+        
+        let result = bigUint * integer
+        
+        XCTAssertEqual(result, 6)
+    }
+    
+    func testMultiplyUInt8AndBigUint() throws {
+        let bigUint: BigUint = 2
+        let integer: UInt8 = 3
+        
+        let result = integer * bigUint
+        
+        XCTAssertEqual(result, 6)
+    }
+    
+    func testMultiplyBigUintAndUInt16() throws {
+        let bigUint: BigUint = 2
+        let integer: UInt16 = 3
+        
+        let result = bigUint * integer
+        
+        XCTAssertEqual(result, 6)
+    }
+    
+    func testMultiplyUInt16AndBigUint() throws {
+        let bigUint: BigUint = 2
+        let integer: UInt16 = 3
+        
+        let result = integer * bigUint
+        
+        XCTAssertEqual(result, 6)
+    }
+    
+    func testMultiplyBigUintAndUInt32() throws {
+        let bigUint: BigUint = 2
+        let integer: UInt32 = 3
+        
+        let result = bigUint * integer
+        
+        XCTAssertEqual(result, 6)
+    }
+    
+    func testMultiplyUInt32AndBigUint() throws {
+        let bigUint: BigUint = 2
+        let integer: UInt32 = 3
+        
+        let result = integer * bigUint
+        
+        XCTAssertEqual(result, 6)
+    }
+    
+    func testMultiplyBigUintAndUInt64() throws {
+        let bigUint: BigUint = 2
+        let integer: UInt64 = 3
+        
+        let result = bigUint * integer
+        
+        XCTAssertEqual(result, 6)
+    }
+    
+    func testMultiplyUInt64AndBigUint() throws {
+        let bigUint: BigUint = 2
+        let integer: UInt64 = 3
+        
+        let result = integer * bigUint
+        
+        XCTAssertEqual(result, 6)
+    }
+    
+    func testMultiplyBigUintAndLiteralInteger() throws {
+        let bigUint: BigUint = 2
+        let integer = 3
+        
+        let result = bigUint * integer
+        
+        XCTAssertEqual(result, 6)
+    }
+    
+    func testMultiplyLiteralIntegerAndBigUint() throws {
+        let bigUint: BigUint = 2
+        let integer = 3
+        
+        let result = integer * bigUint
+        
+        XCTAssertEqual(result, 6)
+    }
+    
+    func testMultiplyAssignBigUint() throws {
+        var result: BigUint = 2
+        let bigUint: BigUint = 3
+        
+        result *= bigUint
+        
+        XCTAssertEqual(result, 6)
+    }
+    
+    func testMultiplyAssignBigUintLiteral() throws {
+        var result: BigUint = 2
+        
+        result *= 3
+        
+        XCTAssertEqual(result, 6)
+    }
+    
+    func testMultiplyAssignBigUintAndUInt8() throws {
+        var result: BigUint = 3
+        let multiplier: UInt8 = 2
+
+        result *= multiplier
+
+        XCTAssertEqual(result, 6)
+    }
+
+    func testMultiplyAssignBigUintAndUInt16() throws {
+        var result: BigUint = 3
+        let multiplier: UInt16 = 2
+
+        result *= multiplier
+
+        XCTAssertEqual(result, 6)
+    }
+
+    func testMultiplyAssignBigUintAndUInt32() throws {
+        var result: BigUint = 3
+        let multiplier: UInt32 = 2
+
+        result *= multiplier
+
+        XCTAssertEqual(result, 6)
+    }
+
+    func testMultiplyAssignBigUintAndUInt64() throws {
+        var result: BigUint = 3
+        let multiplier: UInt64 = 2
+
+        result *= multiplier
+
+        XCTAssertEqual(result, 6)
+    }
+
+    func testMultiplyAssignBigUintAndLiteralInteger() throws {
+        var result: BigUint = 3
+        let multiplier = 2
+
+        result *= multiplier
+
+        XCTAssertEqual(result, 6)
+    }
+
     
     func testDivideTwoBigUint() throws {
         let bigUint1: BigUint = 10
@@ -283,6 +763,61 @@ final class BigUintTests: ContractTestCase {
         }
     }
     
+    func testDivideAssignTwoBigUint() throws {
+        var result: BigUint = 6
+        let divisor: BigUint = 2
+
+        result /= divisor
+
+        XCTAssertEqual(result, 3)
+    }
+    
+    func testDivideAssignBigUintAndUInt8() throws {
+        var result: BigUint = 6
+        let divisor: UInt8 = 2
+
+        result /= divisor
+
+        XCTAssertEqual(result, 3)
+    }
+
+    func testDivideAssignBigUintAndUInt16() throws {
+        var result: BigUint = 6
+        let divisor: UInt16 = 2
+
+        result /= divisor
+
+        XCTAssertEqual(result, 3)
+    }
+
+    func testDivideAssignBigUintAndUInt32() throws {
+        var result: BigUint = 6
+        let divisor: UInt32 = 2
+
+        result /= divisor
+
+        XCTAssertEqual(result, 3)
+    }
+
+    func testDivideAssignBigUintAndUInt64() throws {
+        var result: BigUint = 6
+        let divisor: UInt64 = 2
+
+        result /= divisor
+
+        XCTAssertEqual(result, 3)
+    }
+
+    func testDivideAssignBigUintAndLiteralInteger() throws {
+        var result: BigUint = 6
+        let divisor = 2
+
+        result /= divisor
+
+        XCTAssertEqual(result, 3)
+    }
+
+    
     func testModuloTwoBigUint() throws {
         let bigUint1: BigUint = 10
         let bigUint2: BigUint = 2
@@ -310,6 +845,96 @@ final class BigUintTests: ContractTestCase {
         XCTAssertEqual(result, 2)
     }
     
+    func testModuloBigUintAndUInt8() throws {
+        let bigUint: BigUint = 10
+        let integer: UInt8 = 3
+        
+        let result = bigUint % integer
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testModuloUInt8AndBigUint() throws {
+        let bigUint: BigUint = 3
+        let integer: UInt8 = 10
+        
+        let result = integer % bigUint
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testModuloBigUintAndUInt16() throws {
+        let bigUint: BigUint = 10
+        let integer: UInt16 = 3
+        
+        let result = bigUint % integer
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testModuloUInt16AndBigUint() throws {
+        let bigUint: BigUint = 3
+        let integer: UInt16 = 10
+        
+        let result = integer % bigUint
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testModuloBigUintAndUInt32() throws {
+        let bigUint: BigUint = 10
+        let integer: UInt32 = 3
+        
+        let result = bigUint % integer
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testModuloUInt32AndBigUint() throws {
+        let bigUint: BigUint = 3
+        let integer: UInt32 = 10
+        
+        let result = integer % bigUint
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testModuloBigUintAndUInt64() throws {
+        let bigUint: BigUint = 10
+        let integer: UInt64 = 3
+        
+        let result = bigUint % integer
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testModuloUInt64AndBigUint() throws {
+        let bigUint: BigUint = 3
+        let integer: UInt64 = 10
+        
+        let result = integer % bigUint
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testModuloBigUintAndLiteralInteger() throws {
+        let bigUint: BigUint = 10
+        let integer = 3
+        
+        let result = bigUint % integer
+        
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testModuloLiteralIntegerAndBigUint() throws {
+        let bigUint: BigUint = 3
+        let integer = 10
+        
+        let result = integer % bigUint
+        
+        XCTAssertEqual(result, 1)
+    }
+    
     func testModuloTwoBigUintZeroRightSideShouldFail() throws {
         do {
             try BigUintTestsContract.testable("contract").testModuloTwoBigUintZeroRightSideShouldFail()
@@ -319,6 +944,61 @@ final class BigUintTests: ContractTestCase {
             XCTAssertEqual(error, .userError(message: "Cannot divide by zero (modulo)."))
         }
     }
+    
+    func testModuloAssignTwoBigUints() throws {
+        var result: BigUint = 5
+        let divisor: BigUint = 2
+
+        result %= divisor
+
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testModuloAssignBigUintAndUInt8() throws {
+        var result: BigUint = 5
+        let divisor: UInt8 = 2
+
+        result %= divisor
+
+        XCTAssertEqual(result, 1)
+    }
+
+    func testModuloAssignBigUintAndUInt16() throws {
+        var result: BigUint = 5
+        let divisor: UInt16 = 2
+
+        result %= divisor
+
+        XCTAssertEqual(result, 1)
+    }
+
+    func testModuloAssignBigUintAndUInt32() throws {
+        var result: BigUint = 5
+        let divisor: UInt32 = 2
+
+        result %= divisor
+
+        XCTAssertEqual(result, 1)
+    }
+
+    func testModuloAssignBigUintAndUInt64() throws {
+        var result: BigUint = 5
+        let divisor: UInt64 = 2
+
+        result %= divisor
+
+        XCTAssertEqual(result, 1)
+    }
+
+    func testModuloAssignBigUintAndLiteralInteger() throws {
+        var result: BigUint = 5
+        let divisor = 2
+
+        result %= divisor
+
+        XCTAssertEqual(result, 1)
+    }
+
     
     func testCompareGreaterTrue() throws {
         let bigUint1: BigUint = 5
@@ -339,6 +1019,96 @@ final class BigUintTests: ContractTestCase {
         let bigUint2: BigUint = 5
         
         XCTAssertFalse(bigUint1 > bigUint2)
+    }
+    
+    func testCompareGreaterBigUintAndUInt8() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt8 = 2
+        let integer2: UInt8 = 6
+        
+        XCTAssert(bigUint > integer)
+        XCTAssertFalse(bigUint > integer2)
+    }
+    
+    func testCompareGreaterUInt8AndBigUint() throws {
+        let bigUint: BigUint = 2
+        let bigUint2: BigUint = 6
+        let integer: UInt8 = 5
+        
+        XCTAssert(integer > bigUint)
+        XCTAssertFalse(integer > bigUint2)
+    }
+    
+    func testCompareGreaterBigUintAndUInt16() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt16 = 2
+        let integer2: UInt16 = 6
+        
+        XCTAssert(bigUint > integer)
+        XCTAssertFalse(bigUint > integer2)
+    }
+    
+    func testCompareGreaterUInt16AndBigUint() throws {
+        let bigUint: BigUint = 2
+        let bigUint2: BigUint = 6
+        let integer: UInt16 = 5
+        
+        XCTAssert(integer > bigUint)
+        XCTAssertFalse(integer > bigUint2)
+    }
+    
+    func testCompareGreaterBigUintAndUInt32() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt32 = 2
+        let integer2: UInt32 = 6
+        
+        XCTAssert(bigUint > integer)
+        XCTAssertFalse(bigUint > integer2)
+    }
+    
+    func testCompareGreaterUInt32AndBigUint() throws {
+        let bigUint: BigUint = 2
+        let bigUint2: BigUint = 6
+        let integer: UInt32 = 5
+        
+        XCTAssert(integer > bigUint)
+        XCTAssertFalse(integer > bigUint2)
+    }
+    
+    func testCompareGreaterBigUintAndUInt64() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt64 = 2
+        let integer2: UInt64 = 6
+        
+        XCTAssert(bigUint > integer)
+        XCTAssertFalse(bigUint > integer2)
+    }
+    
+    func testCompareGreaterUInt64AndBigUint() throws {
+        let bigUint: BigUint = 2
+        let bigUint2: BigUint = 6
+        let integer: UInt64 = 5
+        
+        XCTAssert(integer > bigUint)
+        XCTAssertFalse(integer > bigUint2)
+    }
+    
+    func testCompareGreaterBigUintAndLiteralInteger() throws {
+        let bigUint: BigUint = 5
+        let integer = 2
+        let integer2 = 6
+        
+        XCTAssert(bigUint > integer)
+        XCTAssertFalse(bigUint > integer2)
+    }
+    
+    func testCompareGreaterLiteralIntegerAndBigUint() throws {
+        let bigUint: BigUint = 2
+        let bigUint2: BigUint = 6
+        let integer: UInt64 = 5
+        
+        XCTAssert(integer > bigUint)
+        XCTAssertFalse(integer > bigUint2)
     }
     
     func testCompareGreaterOrEqualTrue() throws {
@@ -362,6 +1132,117 @@ final class BigUintTests: ContractTestCase {
         XCTAssertFalse(bigUint1 >= bigUint2)
     }
     
+    func testCompareGreaterOrEqualBigUintAndUInt8() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt8 = 5
+        let integer2: UInt8 = 6
+        let integer3: UInt8 = 4
+        
+        XCTAssert(bigUint >= integer3)
+        XCTAssert(bigUint >= integer)
+        XCTAssertFalse(bigUint >= integer2)
+    }
+
+    func testCompareGreaterOrEqualUInt8AndBigUint() throws {
+        let bigUint: BigUint = 5
+        let bigUint2: BigUint = 6
+        let integer: UInt8 = 5
+        let integer3: UInt8 = 4
+        
+        XCTAssert(integer >= integer3)
+        XCTAssert(integer >= bigUint)
+        XCTAssertFalse(integer >= bigUint2)
+    }
+
+    func testCompareGreaterOrEqualBigUintAndUInt16() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt16 = 5
+        let integer2: UInt16 = 6
+        let integer3: UInt16 = 4
+        
+        XCTAssert(bigUint >= integer3)
+        XCTAssert(bigUint >= integer)
+        XCTAssertFalse(bigUint >= integer2)
+    }
+
+    func testCompareGreaterOrEqualUInt16AndBigUint() throws {
+        let bigUint: BigUint = 5
+        let bigUint2: BigUint = 6
+        let integer: UInt16 = 5
+        let integer3: UInt16 = 4
+        
+        XCTAssert(integer >= integer3)
+        XCTAssert(integer >= bigUint)
+        XCTAssertFalse(integer >= bigUint2)
+    }
+
+    func testCompareGreaterOrEqualBigUintAndUInt32() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt32 = 5
+        let integer2: UInt32 = 6
+        let integer3: UInt32 = 4
+        
+        XCTAssert(bigUint >= integer3)
+        XCTAssert(bigUint >= integer)
+        XCTAssertFalse(bigUint >= integer2)
+    }
+
+    func testCompareGreaterOrEqualUInt32AndBigUint() throws {
+        let bigUint: BigUint = 5
+        let bigUint2: BigUint = 6
+        let integer: UInt32 = 5
+        let integer3: UInt32 = 4
+        
+        XCTAssert(integer >= integer3)
+        XCTAssert(integer >= bigUint)
+        XCTAssertFalse(integer >= bigUint2)
+    }
+
+    func testCompareGreaterOrEqualBigUintAndUInt64() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt64 = 5
+        let integer2: UInt64 = 6
+        let integer3: UInt64 = 4
+        
+        XCTAssert(bigUint >= integer3)
+        XCTAssert(bigUint >= integer)
+        XCTAssertFalse(bigUint >= integer2)
+    }
+
+    func testCompareGreaterOrEqualUInt64AndBigUint() throws {
+        let bigUint: BigUint = 5
+        let bigUint2: BigUint = 6
+        let integer: UInt64 = 5
+        let integer3: UInt64 = 4
+        
+        XCTAssert(integer >= integer3)
+        XCTAssert(integer >= bigUint)
+        XCTAssertFalse(integer >= bigUint2)
+    }
+
+    func testCompareGreaterOrEqualBigUintAndLiteralInteger() throws {
+        let bigUint: BigUint = 5
+        let integer = 5
+        let integer2 = 6
+        let integer3 = 4
+        
+        XCTAssert(bigUint >= integer3)
+        XCTAssert(bigUint >= integer)
+        XCTAssertFalse(bigUint >= integer2)
+    }
+
+    func testCompareGreaterOrEqualLiteralIntegerAndBigUint() throws {
+        let bigUint: BigUint = 5
+        let bigUint2: BigUint = 6
+        let integer = 5
+        let integer3 = 4
+        
+        XCTAssert(integer >= integer3)
+        XCTAssert(integer >= bigUint)
+        XCTAssertFalse(integer >= bigUint2)
+    }
+
+    
     func testCompareLessTrue() throws {
         let bigUint1: BigUint = 2
         let bigUint2: BigUint = 5
@@ -382,6 +1263,187 @@ final class BigUintTests: ContractTestCase {
         
         XCTAssertFalse(bigUint1 < bigUint2)
     }
+    
+    func testCompareLessThanBigUintAndUInt8() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt8 = 5
+
+        XCTAssertFalse(bigUint < integer)
+    }
+
+    func testCompareLessThanUInt8AndBigUint() throws {
+        let bigUint: BigUint = 5
+        let integer3: UInt8 = 4
+        let integer: UInt8 = 5
+        let integer2: UInt8 = 6
+
+        XCTAssert(integer3 < bigUint)
+        XCTAssertFalse(integer < bigUint)
+        XCTAssertFalse(integer2 < bigUint)
+    }
+
+    func testCompareLessThanBigUintAndUInt16() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt16 = 5
+
+        XCTAssertFalse(bigUint < integer)
+    }
+
+    func testCompareLessThanUInt16AndBigUint() throws {
+        let bigUint: BigUint = 5
+        let integer3: UInt16 = 4
+        let integer: UInt16 = 5
+        let integer2: UInt16 = 6
+
+        XCTAssert(integer3 < bigUint)
+        XCTAssertFalse(integer < bigUint)
+        XCTAssertFalse(integer2 < bigUint)
+    }
+
+    func testCompareLessThanBigUintAndUInt32() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt32 = 5
+
+        XCTAssertFalse(bigUint < integer)
+    }
+
+    func testCompareLessThanUInt32AndBigUint() throws {
+        let bigUint: BigUint = 5
+        let integer3: UInt32 = 4
+        let integer: UInt32 = 5
+        let integer2: UInt32 = 6
+
+        XCTAssert(integer3 < bigUint)
+        XCTAssertFalse(integer < bigUint)
+        XCTAssertFalse(integer2 < bigUint)
+    }
+
+    func testCompareLessThanBigUintAndUInt64() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt64 = 5
+
+        XCTAssertFalse(bigUint < integer)
+    }
+
+    func testCompareLessThanUInt64AndBigUint() throws {
+        let bigUint: BigUint = 5
+        let integer3: UInt64 = 4
+        let integer: UInt64 = 5
+        let integer2: UInt64 = 6
+
+        XCTAssert(integer3 < bigUint)
+        XCTAssertFalse(integer < bigUint)
+        XCTAssertFalse(integer2 < bigUint)
+    }
+
+    func testCompareLessThanBigUintAndLiteralInteger() throws {
+        let bigUint: BigUint = 5
+        let integer = 5
+
+        XCTAssertFalse(bigUint < integer)
+    }
+
+    func testCompareLessThanLiteralIntegerAndBigUint() throws {
+        let bigUint: BigUint = 5
+        let integer3 = 4
+        let integer = 5
+        let integer2 = 6
+
+        XCTAssert(integer3 < bigUint)
+        XCTAssertFalse(integer < bigUint)
+        XCTAssertFalse(integer2 < bigUint)
+    }
+    
+    func testCompareLessOrEqualBigUintAndUInt8() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt8 = 5
+
+        XCTAssert(bigUint <= integer)
+    }
+
+    func testCompareLessOrEqualUInt8AndBigUint() throws {
+        let bigUint: BigUint = 5
+        let integer2: UInt8 = 4
+        let integer: UInt8 = 5
+        let integer3: UInt8 = 6
+
+        XCTAssert(integer2 <= bigUint)
+        XCTAssert(integer <= bigUint)
+        XCTAssertFalse(integer3 <= bigUint)
+    }
+
+    func testCompareLessOrEqualBigUintAndUInt16() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt16 = 5
+
+        XCTAssert(bigUint <= integer)
+    }
+
+    func testCompareLessOrEqualUInt16AndBigUint() throws {
+        let bigUint: BigUint = 5
+        let integer2: UInt16 = 4
+        let integer: UInt16 = 5
+        let integer3: UInt16 = 6
+
+        XCTAssert(integer2 <= bigUint)
+        XCTAssert(integer <= bigUint)
+        XCTAssertFalse(integer3 <= bigUint)
+    }
+
+    func testCompareLessOrEqualBigUintAndUInt32() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt32 = 5
+
+        XCTAssert(bigUint <= integer)
+    }
+
+    func testCompareLessOrEqualUInt32AndBigUint() throws {
+        let bigUint: BigUint = 5
+        let integer2: UInt32 = 4
+        let integer: UInt32 = 5
+        let integer3: UInt32 = 6
+
+        XCTAssert(integer2 <= bigUint)
+        XCTAssert(integer <= bigUint)
+        XCTAssertFalse(integer3 <= bigUint)
+    }
+
+    func testCompareLessOrEqualBigUintAndUInt64() throws {
+        let bigUint: BigUint = 5
+        let integer: UInt64 = 5
+
+        XCTAssert(bigUint <= integer)
+    }
+
+    func testCompareLessOrEqualUInt64AndBigUint() throws {
+        let bigUint: BigUint = 5
+        let integer2: UInt64 = 4
+        let integer: UInt64 = 5
+        let integer3: UInt64 = 6
+
+        XCTAssert(integer2 <= bigUint)
+        XCTAssert(integer <= bigUint)
+        XCTAssertFalse(integer3 <= bigUint)
+    }
+
+    func testCompareLessOrEqualBigUintAndLiteralInteger() throws {
+        let bigUint: BigUint = 5
+        let integer = 5
+
+        XCTAssert(bigUint <= integer)
+    }
+
+    func testCompareLessOrEqualLiteralIntegerAndBigUint() throws {
+        let bigUint: BigUint = 5
+        let integer2 = 4
+        let integer = 5
+        let integer3 = 6
+
+        XCTAssert(integer2 <= bigUint)
+        XCTAssert(integer <= bigUint)
+        XCTAssertFalse(integer3 <= bigUint)
+    }
+
     
     func testZeroBigUintTopEncode() throws {
         let bigUint: BigUint = 0


### PR DESCRIPTION
It has not been done for literal integer and Int to avoid the compiler to be confused since BigUint can be constructed from a literal integer

Fixes #43 