### PR TITLE
Implemented async calls on SwiftVM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,6 +56,12 @@ if !isWasm {
     
     testTargets.append(contentsOf: [
         .testTarget(
+            name: "AsyncCallsTests",
+            dependencies: [
+                "Space"
+            ]
+        ),
+        .testTarget(
             name: "BufferTests",
             dependencies: [
                 "Space"

--- a/Sources/Space/api/dummy/DummyApi.swift
+++ b/Sources/Space/api/dummy/DummyApi.swift
@@ -250,8 +250,8 @@ public class DummyApi {
                 input: TransactionInput(
                     contractAddress: execution.input.callerAddress,
                     callerAddress: execution.input.contractAddress,
-                    egldValue: execution.input.egldValue,
-                    esdtValue: execution.input.esdtValue,
+                    egldValue: 0,
+                    esdtValue: [],
                     arguments: asyncCallResults
                 ),
                 callbackClosure: errorCallback.args,

--- a/Sources/Space/api/dummy/TransactionContainer.swift
+++ b/Sources/Space/api/dummy/TransactionContainer.swift
@@ -301,18 +301,18 @@ package final class TransactionContainer: @unchecked Sendable {
         inputs: TransactionInput,
         shouldBePerformedInAChildContainer: Bool = true // useful for async calls, see DummyApi's executePendingAsyncExecution
     ) -> [Data] {
-        self.performEgldOrEsdtTransfers(
-            senderAddress: inputs.callerAddress,
-            receiverAddress: receiver,
-            egldValue: inputs.egldValue,
-            esdtValue: inputs.esdtValue
-        )
-        
         let endpointName = String(data: function, encoding: .utf8)!
         let receiverAccount = self.getAccount(address: receiver)
         var selector = self.getContractEndpointSelectorForContractAccount(contractAccount: receiverAccount)
         
         if shouldBePerformedInAChildContainer {
+            self.performEgldOrEsdtTransfers(
+                senderAddress: inputs.callerAddress,
+                receiverAddress: receiver,
+                egldValue: inputs.egldValue,
+                esdtValue: inputs.esdtValue
+            )
+            
             let nestedCallTransactionContainer = TransactionContainer(
                 worldState: self.state,
                 transactionInput: inputs,
@@ -326,7 +326,6 @@ package final class TransactionContainer: @unchecked Sendable {
         
         selector._callEndpoint(name: endpointName)
         
-        let outputData: [Data]
         if shouldBePerformedInAChildContainer {
             guard let nestedCallTransactionContainer = self.nestedCallTransactionContainer else {
                 fatalError("Should not be executed")

--- a/Sources/Space/api/dummy/io/input/AsyncCallInput.swift
+++ b/Sources/Space/api/dummy/io/input/AsyncCallInput.swift
@@ -1,0 +1,9 @@
+#if !WASM
+import Foundation
+
+package struct AsyncCallInput {
+    let function: Data
+    let isCallback: Bool
+    let input: TransactionInput
+}
+#endif

--- a/Sources/Space/api/dummy/io/input/AsyncCallInput.swift
+++ b/Sources/Space/api/dummy/io/input/AsyncCallInput.swift
@@ -1,9 +1,16 @@
 #if !WASM
 import Foundation
 
+package struct AsyncCallCallbackInput {
+    let function: Data
+    let args: Data
+}
+
 package struct AsyncCallInput {
     let function: Data
-    let isCallback: Bool
     let input: TransactionInput
+    let callbackClosure: Data? // != nil means it is a callback execution
+    let successCallback: AsyncCallCallbackInput?
+    let errorCallback: AsyncCallCallbackInput?
 }
 #endif

--- a/Sources/Space/api/dummy/io/output/TransactionOutput.swift
+++ b/Sources/Space/api/dummy/io/output/TransactionOutput.swift
@@ -2,20 +2,22 @@
 import Foundation
 
 public class TransactionOutput {
+    package var results: [TransactionOutputResult] = []
     package var logs: [TransactionOutputLogRaw] = []
     
     public init() {}
     
     package func copied() -> TransactionOutput {
         let output = TransactionOutput()
+        output.results = results
         output.logs = logs
         
         return output
     }
     
     package func merge(output: TransactionOutput) {
+        self.results.append(contentsOf: output.results)
         self.logs.append(contentsOf: output.logs)
-        print(logs)
     }
     
     package func writeLog(log: TransactionOutputLogRaw) {

--- a/Sources/Space/api/dummy/io/output/TransactionOutputResult.swift
+++ b/Sources/Space/api/dummy/io/output/TransactionOutputResult.swift
@@ -1,0 +1,8 @@
+#if !WASM
+import Foundation
+
+public struct TransactionOutputResult {
+    public let contractAddress: Data
+    public var results: [Data]
+}
+#endif

--- a/Sources/Space/api/vm/VMApi.swift
+++ b/Sources/Space/api/vm/VMApi.swift
@@ -1,5 +1,7 @@
 #if WASM
 
+nonisolated(unsafe) var nextHandle: Int32 = -100
+
 // TODO: /!\ CRITICAL /!\ Handle all possible errors from the Int32 status code. For example substracting two BigUint A - B, where A < B, DOESN'T throw an error in the VM
 
 // MARK: Buffer-related OPCODES
@@ -292,7 +294,16 @@ func managedVerifyEd25519(keyHandle: Int32, messageHandle: Int32, sigHandle: Int
 @_extern(c)
 func managedSha256(inputHandle: Int32, outputHandle: Int32) -> Int32
 
-struct VMApi {}
+struct VMApi {
+    
+    public func getNextHandle() -> Int32 {
+        let currentHandle = nextHandle
+        nextHandle -= 1
+
+        return currentHandle
+    }
+    
+}
 
 // MARK: BufferApi Implementation
 

--- a/Sources/Space/codec/arguments/CallbackClosureLoader.swift
+++ b/Sources/Space/codec/arguments/CallbackClosureLoader.swift
@@ -4,7 +4,7 @@ public struct CallbackClosureLoader {
     let argBuffer: ArgBuffer
     
     public init() {
-        var bufferSerialized = Buffer()
+        let bufferSerialized = Buffer()
         
         API.managedGetCallbackClosure(callbackClosureHandle: bufferSerialized.handle)
         

--- a/Sources/Space/codec/arguments/EndpointArgumentsLoader.swift
+++ b/Sources/Space/codec/arguments/EndpointArgumentsLoader.swift
@@ -13,7 +13,7 @@ extension EndpointArgumentsLoader: TopDecodeMultiInput {
     }
     
     public mutating func nextValueInput() -> Buffer {
-        let bufferHandle = getNextHandle()
+        let bufferHandle = API.getNextHandle()
         let _ = API.bufferGetArgument(argId: self.currentIndex, bufferHandle: bufferHandle)
         
         self.currentIndex += 1

--- a/Sources/Space/lib.swift
+++ b/Sources/Space/lib.swift
@@ -24,11 +24,3 @@ public macro Event(dataType: TopEncode.Type? = nil) = #externalMacro(module: "Ev
 
 @attached(extension, names: arbitrary)
 public macro Proxy() = #externalMacro(module: "ProxyMacro", type: "Proxy")
-
-nonisolated(unsafe) var nextHandle: Int32 = -100
-func getNextHandle() -> Int32 {
-    let currentHandle = nextHandle
-    nextHandle -= 1
-
-    return currentHandle
-}

--- a/Sources/Space/random/Randomness.swift
+++ b/Sources/Space/random/Randomness.swift
@@ -1,5 +1,5 @@
 public struct Randomness {
-    public static let bufferHandle = getNextHandle()
+    public static let bufferHandle = API.getNextHandle()
     
     // Workaround for isolation
     private static func getBuffer() -> Buffer {

--- a/Sources/Space/storage/SingleValueMapper.swift
+++ b/Sources/Space/storage/SingleValueMapper.swift
@@ -23,7 +23,7 @@ public struct SingleValueMapper<V: TopEncode & TopDecode>: StorageMapper {
     }
     
     private func getRawBuffer() -> Buffer {
-        let storedValueBufferHandle = getNextHandle()
+        let storedValueBufferHandle = API.getNextHandle()
         let _ = API.bufferStorageLoad(keyHandle: self.key.handle, bufferHandle: storedValueBufferHandle)
         
         return Buffer(handle: storedValueBufferHandle)

--- a/Sources/Space/tests/utils/TransactionError.swift
+++ b/Sources/Space/tests/utils/TransactionError.swift
@@ -15,6 +15,17 @@ public enum TransactionError: Error, Equatable {
             return message
         }
     }
+    
+    var code: UInt32 {
+        switch self {
+        case .userError(let message):
+            4
+        case .executionFailed(let reason):
+            10
+        case .worldError(let message):
+            100
+        }
+    }
 }
 
 #endif

--- a/Sources/Space/tests/utils/runTestCall.swift
+++ b/Sources/Space/tests/utils/runTestCall.swift
@@ -8,45 +8,20 @@ public func runTestCall<each InputArg: TopEncodeMulti & TopDecodeMulti, ReturnTy
     args: (repeat each InputArg),
     transactionInput: TransactionInput,
     transactionOutput: TransactionOutput = TransactionOutput(),
-    operation: @escaping (repeat each InputArg) -> ReturnType
+    operation: @escaping (repeat each InputArg) -> Void
 ) throws(TransactionError) -> ReturnType {
-    // Pushing a container makes the previous handles invalid.
-    // Thus, we have to inject the data into the new container.
-    var concatenatedInputArgsBuffers = Vector<Buffer>() // We don't want the same encoding as Vector, since we will dep decode multiple types, the same way as a struct
-    for value in repeat each args {
-        value.multiEncode(output: &concatenatedInputArgsBuffers)
-    }
-    
-    var concatenatedInputArgsBuffersBytes: [[UInt8]] = []
-    concatenatedInputArgsBuffers.forEach { value in
-        concatenatedInputArgsBuffersBytes.append(value.toBytes())
-    }
-    
-    var bytesData: [[UInt8]] = []
-    
-    try API.runTransactions(
+    let results = try API.runTransactions(
         transactionInput: transactionInput,
         transactionOutput: transactionOutput,
         operations: UncheckedClosure {
-            var injectedInputBuffers: Vector<Buffer> = Vector()
-            for bytes in concatenatedInputArgsBuffersBytes {
-                injectedInputBuffers = injectedInputBuffers.appended(Buffer(data: bytes))
-            }
-            
-            let result = operation(repeat (each InputArg)(topDecodeMulti: &injectedInputBuffers))
-            
-            var bytesDataBuffers = Vector<Buffer>()
-            result.multiEncode(output: &bytesDataBuffers)
-            
-            bytesDataBuffers.forEach { value in
-                bytesData.append(value.toBytes()) // We have to extract the bytes from the transaction context...
-            }
+            operation(repeat each args)
         }
     )
     
-    var extractedResultBuffers: Vector<Buffer> = Vector() // ...and reinject it in the root context
-    for bytes in bytesData {
-        extractedResultBuffers = extractedResultBuffers.appended(Buffer(data: bytes))
+    var extractedResultBuffers: Vector<Buffer> = Vector()
+    
+    for bytes in results {
+        extractedResultBuffers = extractedResultBuffers.appended(Buffer(data: Array(bytes)))
     }
     
     let extractedResult = ReturnType(topDecodeMulti: &extractedResultBuffers)
@@ -62,28 +37,11 @@ public func runTestCall<each InputArg: TopEncodeMulti & TopDecodeMulti>(
     transactionOutput: TransactionOutput = TransactionOutput(),
     operation: @escaping (repeat each InputArg) -> Void
 ) throws(TransactionError) {
-    // Pushing a container makes the previous handles invalid.
-    // Thus, we have to inject the data into the new container.
-    var concatenatedInputArgsBuffers = Vector<Buffer>() // We don't want the same encoding as Vector, since we will dep decode multiple types, the same way as a struct
-    for value in repeat each args {
-        value.multiEncode(output: &concatenatedInputArgsBuffers)
-    }
-    
-    var concatenatedInputArgsBuffersBytes: [[UInt8]] = []
-    concatenatedInputArgsBuffers.forEach { value in
-        concatenatedInputArgsBuffersBytes.append(value.toBytes())
-    }
-    
-    try API.runTransactions(
+    let _ = try API.runTransactions(
         transactionInput: transactionInput,
         transactionOutput: transactionOutput,
         operations: UncheckedClosure {
-            var injectedInputBuffers: Vector<Buffer> = Vector()
-            for bytes in concatenatedInputArgsBuffersBytes {
-                injectedInputBuffers = injectedInputBuffers.appended(Buffer(data: bytes))
-            }
-            
-            operation(repeat (each InputArg)(topDecodeMulti: &injectedInputBuffers))
+            operation(repeat each args)
         }
     )
 }

--- a/Sources/Space/tests/utils/runTestCall.swift
+++ b/Sources/Space/tests/utils/runTestCall.swift
@@ -16,7 +16,7 @@ public func runTestCall<each InputArg: TopEncodeMulti & TopDecodeMulti, ReturnTy
         operations: UncheckedClosure {
             operation(repeat each args)
         }
-    )
+    ).results
     
     var extractedResultBuffers: Vector<Buffer> = Vector()
     

--- a/Sources/Space/types/BigUint.swift
+++ b/Sources/Space/types/BigUint.swift
@@ -10,7 +10,7 @@ public struct BigUint {
             smartContractError(message: "Cannot convert negative Int64 to BigUint.")
         }
         
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         API.bigIntSetInt64(destination: handle, value: value)
         self.handle = handle
     }
@@ -36,13 +36,13 @@ public struct BigUint {
     }
 
     package init(value: Bytes8) {
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         API.bigIntSetInt64(destination: handle, value: toBigEndianInt64(from: value))
         self.handle = handle
     }
     
     public init(bigEndianBuffer: Buffer) {
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         let _ = API.bufferToBigIntUnsigned(bufferHandle: bigEndianBuffer.handle, bigIntHandle: handle)
         
         self.handle = handle
@@ -53,7 +53,7 @@ public struct BigUint {
     }
 
     public func toBuffer() -> Buffer {
-        let destHandle = getNextHandle()
+        let destHandle = API.getNextHandle()
         API.bigIntToBuffer(bigIntHandle: self.handle, destHandle: destHandle)
 
         return Buffer(handle: destHandle)
@@ -64,7 +64,7 @@ public struct BigUint {
     }
     
     func toBytesBigEndianBuffer() -> Buffer {
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         let _ = API.bufferFromBigIntUnsigned(bufferHandle: handle, bigIntHandle: self.handle)
         
         return Buffer(handle: handle)
@@ -79,7 +79,7 @@ extension BigUint: Equatable {
 
 extension BigUint {
     public static func + (left: BigUint, right: BigUint) -> BigUint {
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         API.bigIntAdd(destHandle: handle, lhsHandle: left.handle, rhsHandle: right.handle)
         
         return BigUint(handle: handle)
@@ -94,14 +94,14 @@ extension BigUint {
             smartContractError(message: Buffer(stringLiteral: BIG_UINT_SUB_NEGATIVE))
         }
         
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         API.bigIntSub(destHandle: handle, lhsHandle: lhs.handle, rhsHandle: rhs.handle)
         
         return BigUint(handle: handle)
     }
     
     public static func * (lhs: BigUint, rhs: BigUint) -> BigUint {
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         API.bigIntMul(destHandle: handle, lhsHandle: lhs.handle, rhsHandle: rhs.handle)
         
         return BigUint(handle: handle)
@@ -109,7 +109,7 @@ extension BigUint {
     
     public static func / (lhs: BigUint, rhs: BigUint) -> BigUint {
         // TODO: be sure rhs == 0 throws an error on the SpaceVM (critical)
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         API.bigIntTDiv(destHandle: handle, lhsHandle: lhs.handle, rhsHandle: rhs.handle)
         
         return BigUint(handle: handle)
@@ -117,7 +117,7 @@ extension BigUint {
     
     public static func % (lhs: BigUint, rhs: BigUint) -> BigUint {
         // TODO: be sure rhs == 0 throws an error on the SpaceVM (critical)
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         API.bigIntTMod(destHandle: handle, lhsHandle: lhs.handle, rhsHandle: rhs.handle)
         
         return BigUint(handle: handle)
@@ -215,7 +215,7 @@ extension BigUint: CustomDebugStringConvertible {
 
 extension BigUint {
     public var stringDescription: String {
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         API.bigIntToString(bigIntHandle: self.handle, destHandle: handle)
         let utf8Buffer = Buffer(handle: handle)
         

--- a/Sources/Space/types/Buffer.swift
+++ b/Sources/Space/types/Buffer.swift
@@ -22,7 +22,7 @@ public struct Buffer {
     }
 
     public init(_ string: StaticString) {
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         let _ = API.bufferSetBytes(handle: handle, bytePtr: string.utf8Start, byteLen: Int32(string.utf8CodeUnitCount))
 
         self.handle = handle
@@ -35,7 +35,7 @@ public struct Buffer {
     
     @inline(__always)
     package init(data: [UInt8]) {
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         
         var data = data
         
@@ -47,7 +47,7 @@ public struct Buffer {
     
     @inline(__always)
     package init(data: UInt8) {
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         
         var data = data
         
@@ -58,7 +58,7 @@ public struct Buffer {
     
     @inline(__always)
     package init(data: Bytes2) {
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         
         var data = data
         
@@ -69,7 +69,7 @@ public struct Buffer {
     
     @inline(__always)
     package init(data: Bytes4) {
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         
         var data = data
         
@@ -80,7 +80,7 @@ public struct Buffer {
     
     @inline(__always)
     package init(data: Bytes8) {
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         
         var data = data
         
@@ -91,7 +91,7 @@ public struct Buffer {
     
     @inline(__always)
     package init(data: Bytes32) {
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         
         var data = data
         
@@ -237,7 +237,7 @@ public struct Buffer {
     }
     
     public func toHexadecimalBuffer() -> Buffer {
-        let resultHandle = getNextHandle()
+        let resultHandle = API.getNextHandle()
         
         API.managedBufferToHex(sourceHandle: self.handle, destinationHandle: resultHandle)
         

--- a/Sources/Space/wrappers/Blockchain.swift
+++ b/Sources/Space/wrappers/Blockchain.swift
@@ -16,7 +16,7 @@ public struct Blockchain {
     private init() {}
     
     public static func getSCAddress() -> Address {
-        let handle = getNextHandle()
+        let handle = API.getNextHandle()
         
         API.managedSCAddress(resultHandle: handle)
         
@@ -50,7 +50,7 @@ public struct Blockchain {
     ) -> BigUint {
         var addressBytes = address.buffer.to32BytesStackArray()
         
-        let destHandle = getNextHandle()
+        let destHandle = API.getNextHandle()
         
         API.bigIntGetExternalBalance(
             addressPtr: &addressBytes,
@@ -68,7 +68,7 @@ public struct Blockchain {
         var addressBytes = address.buffer.to32BytesStackArray()
         var tokenIdentifierBytes = tokenIdentifier.to32BytesStackArray()
         
-        let destHandle = getNextHandle()
+        let destHandle = API.getNextHandle()
         
         API.bigIntGetESDTExternalBalance(
             addressPtr: &addressBytes,
@@ -83,7 +83,7 @@ public struct Blockchain {
 
     public static func getOwner() -> Address {
         // TODO: add caching
-        let resultHandle = getNextHandle()
+        let resultHandle = API.getNextHandle()
         
         API.managedOwnerAddress(resultHandle: resultHandle)
         

--- a/Sources/Space/wrappers/Message.swift
+++ b/Sources/Space/wrappers/Message.swift
@@ -83,7 +83,7 @@ public struct Message {
     
     public static var transactionHash: Buffer {
         // TODO: add caching
-        var result = Buffer()
+        let result = Buffer()
         
         API.managedGetOriginalTxHash(resultHandle: result.handle)
         

--- a/Sources/Space/wrappers/Message.swift
+++ b/Sources/Space/wrappers/Message.swift
@@ -3,7 +3,7 @@ public struct Message {
     
     public static var egldValue: BigUint {
         // TODO: add caching
-        let valueHandle = getNextHandle()
+        let valueHandle = API.getNextHandle()
         
         API.bigIntGetCallValue(dest: valueHandle)
         
@@ -12,7 +12,7 @@ public struct Message {
 
     public static var allEsdtTransfers: Vector<TokenPayment> {
         // TODO: add caching
-        let resultHandle = getNextHandle()
+        let resultHandle = API.getNextHandle()
         
         API.managedGetMultiESDTCallValue(resultHandle: resultHandle)
         

--- a/Tests/AsyncCallsTests/AsyncCallsTests.swift
+++ b/Tests/AsyncCallsTests/AsyncCallsTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+import Space
+
+@Contract struct CalleeContract {
+    @Storage(key: "counter") var counter: BigUint
+    
+    public mutating func increaseCounter() {
+        self.counter += 1
+    }
+    
+    public mutating func increaseCounterBy(value: BigUint) {
+        self.counter += value
+    }
+    
+    public func returnValueNoInput() -> Buffer {
+        return "Hello World!"
+    }
+    
+    public mutating func increaseCounterAndFail() {
+        self.counter += 1
+        
+        smartContractError(message: "Oh no!")
+    }
+    
+    public func getCounter() -> BigUint {
+        self.counter
+    }
+}
+
+@Proxy enum CalleeContractProxy {
+    case increaseCounter
+    case increaseCounterBy(value: BigUint)
+    case increaseCounterAndFail
+    case returnValueNoInput
+}
+
+@Contract struct AsyncCallsTestsContract {
+    @Storage(key: "counter") var counter: BigUint
+    
+    public func asyncCallIncreaseCounter(receiver: Address) {
+        CalleeContractProxy
+            .increaseCounter
+            .registerPromise(
+                receiver: receiver,
+                gas: 10_000_000
+            )
+    }
+    
+    public func asyncCallIncreaseCounterBy(
+        receiver: Address,
+        value: BigUint
+    ) {
+        CalleeContractProxy
+            .increaseCounterBy(value: value)
+            .registerPromise(
+                receiver: receiver,
+                gas: 10_000_000
+            )
+    }
+    
+    public mutating func asyncCallIncreaseCounterAndFail(receiver: Address) {
+        self.counter += 100
+        
+        CalleeContractProxy
+            .increaseCounterAndFail
+            .registerPromise(
+                receiver: receiver,
+                gas: 10_000_000
+            )
+        
+        self.counter += 150
+    }
+    
+    public func getCounter() -> BigUint {
+        self.counter
+    }
+}
+
+final class AsyncCallsTests: ContractTestCase {
+
+    override var initialAccounts: [WorldAccount] {
+        [
+            WorldAccount(address: "callee"),
+            WorldAccount(address: "caller")
+        ]
+    }
+    
+    func testIncreaseCounter() throws {
+        let callee = try CalleeContract.testable("callee")
+        let caller = try AsyncCallsTestsContract.testable("caller")
+        
+        try caller.asyncCallIncreaseCounter(receiver: "callee")
+        
+        let counter = try callee.getCounter()
+        
+        XCTAssertEqual(counter, 1)
+    }
+    
+    func testIncreaseCounterBy() throws {
+        let callee = try CalleeContract.testable("callee")
+        let caller = try AsyncCallsTestsContract.testable("caller")
+        
+        try caller.asyncCallIncreaseCounterBy(
+            receiver: "callee",
+            value: 150
+        )
+        
+        let counter = try callee.getCounter()
+        
+        XCTAssertEqual(counter, 150)
+    }
+    
+    func testChangeStorageAndStartFailableAsyncCall() throws {
+        let callee = try CalleeContract.testable("callee")
+        var caller = try AsyncCallsTestsContract.testable("caller")
+        
+        try caller.asyncCallIncreaseCounterAndFail(
+            receiver: "callee"
+        )
+        
+        let calleeCounter = try callee.getCounter()
+        let callerCounter = try caller.getCounter()
+        
+        XCTAssertEqual(calleeCounter, 0)
+        XCTAssertEqual(callerCounter, 250)
+    }
+}


### PR DESCRIPTION
The current implementation misses two things:

- ESDT transfers, which will be implemented on async calls once they are on sync calls.
- Transaction outputs and logs for intermediate calls. They are only needed for debugging purpose, therefore they will be implemented later. An issue is going to be opened on this subject.